### PR TITLE
Docs: devcontainer notes

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 A base [Docker image](https://www.docker.com/) for Cal-ITP Python web applications.
 
-Read the full documentation online: <https://docs.cal-itp.org/docker-python-web>
+Read the full documentation online: <https://docs.calitp.org/docker-python-web>
 
 ## Features
 

--- a/README.md
+++ b/README.md
@@ -38,6 +38,19 @@ Or from the command line:
 docker pull ghcr.io/cal-itp/docker-python-web:main
 ```
 
+## Development
+
+Development for this repo is done within a Visual Studio Code [devcontainer](https://code.visualstudio.com/docs/remote/containers).
+
+!!! warning
+
+    You must build the base Docker image `cal-itp/docker-python-web:app` before running the devcontainer. In a terminal, run:
+    ```
+    docker compose build app
+    ```
+
+Then, with the [Remote - Containers](https://code.visualstudio.com/docs/remote/containers) extension enabled, open the folder containing this repository inside Visual Studio Code.
+
 ## License
 
 [Apache 2.0](LICENSE)

--- a/docs/README.md
+++ b/docs/README.md
@@ -39,3 +39,16 @@ Or from the command line:
 ```shell
 docker pull ghcr.io/cal-itp/docker-python-web:main
 ```
+
+## Development
+
+Development for this repo is done within a Visual Studio Code [devcontainer](https://code.visualstudio.com/docs/remote/containers).
+
+!!! warning
+
+    You must build the base Docker image `cal-itp/docker-python-web:app` before running the devcontainer. In a terminal, run:
+    ```
+    docker compose build app
+    ```
+
+Then, with the [Remote - Containers](https://code.visualstudio.com/docs/remote/containers) extension enabled, open the folder containing this repository inside Visual Studio Code.


### PR DESCRIPTION
This PR fixes the URL for the docs site and adds some notes about necessary steps to open the devcontainer.

Related to cal-itp/eligibility-server#123