### PR TITLE
Fix: markdownlint errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,8 @@ docker pull ghcr.io/cal-itp/docker-python-web:main
 Development for this repo is done within a Visual Studio Code [devcontainer](https://code.visualstudio.com/docs/remote/containers).
 
 You must build the base Docker image `cal-itp/docker-python-web:app` before running the devcontainer. In a terminal, run:
-```
+
+```bash
 docker compose build app
 ```
 


### PR DESCRIPTION
```
calitp@f8536ca720de:~/app$ pre-commit run --all-files
markdownlint.............................................................Failed
- hook id: markdownlint
- exit code: 1

README.md:46 MD031/blanks-around-fences Fenced code blocks should be surrounded by blank lines [Context: "```"]
README.md:46 MD040/fenced-code-language Fenced code blocks should have a language specified [Context: "```"]
```

This stemmed from [an edit I made within GitHub](https://github.com/cal-itp/docker-python-web/commit/e6d211e12c26e4550eeec8954b98d1fa7e3d449d) that pushed directly to `main` without running pre-commit.