### PR TITLE
Refactor: move the application directory up a level

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -3,28 +3,28 @@
   "dockerComposeFile": ["../compose.yml"],
   "service": "dev",
   "runServices": ["dev", "docs"],
-  "workspaceFolder": "/home/calitp/app",
+  "workspaceFolder": "/calitp/app",
   "postAttachCommand": ["/bin/bash", ".devcontainer/postAttach.sh"],
   // Set *default* container specific settings.json values on container create.
   "customizations": {
     "vscode": {
-  "settings": {
-    "terminal.integrated.defaultProfile.linux": "bash",
-    "terminal.integrated.profiles.linux": {
-      "bash": {
-        "path": "/bin/bash"
-      }
-    }
-  },
-  // Add the IDs of extensions you want installed when the container is created.
-  "extensions": [
-    "bpruitt-goddard.mermaid-markdown-syntax-highlighting",
-    "eamodio.gitlens",
-    "esbenp.prettier-vscode",
-    "mhutchie.git-graph",
-    "ms-python.python",
-    "ms-python.vscode-pylance"
-  ]
+      "settings": {
+        "terminal.integrated.defaultProfile.linux": "bash",
+        "terminal.integrated.profiles.linux": {
+          "bash": {
+            "path": "/bin/bash"
+          }
+        }
+      },
+      // Add the IDs of extensions you want installed when the container is created.
+      "extensions": [
+        "bpruitt-goddard.mermaid-markdown-syntax-highlighting",
+        "eamodio.gitlens",
+        "esbenp.prettier-vscode",
+        "mhutchie.git-graph",
+        "ms-python.python",
+        "ms-python.vscode-pylance"
+      ]
     }
   }
 }

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -6,6 +6,8 @@
   "workspaceFolder": "/home/calitp/app",
   "postAttachCommand": ["/bin/bash", ".devcontainer/postAttach.sh"],
   // Set *default* container specific settings.json values on container create.
+  "customizations": {
+    "vscode": {
   "settings": {
     "terminal.integrated.defaultProfile.linux": "bash",
     "terminal.integrated.profiles.linux": {
@@ -23,4 +25,6 @@
     "ms-python.python",
     "ms-python.vscode-pylance"
   ]
+    }
+  }
 }

--- a/appcontainer/Dockerfile
+++ b/appcontainer/Dockerfile
@@ -20,16 +20,16 @@ RUN useradd --create-home --shell /bin/bash $USER && \
     touch /var/run/nginx.pid && \
     chown -R $USER /var/run/nginx.pid && \
     # setup directories and permissions for gunicorn, (eventual) app
-    mkdir -p /home/$USER/app && \
-    mkdir -p /home/$USER/run && \
-    chown -R $USER /home/$USER && \
+    mkdir -p /$USER/app && \
+    mkdir -p /$USER/run && \
+    chown -R $USER /$USER && \
     # install server components
     apt-get update && \
     apt-get install -qq --no-install-recommends build-essential nginx gettext && \
     python -m pip install --upgrade pip
 
 # enter run (gunicorn) directory
-WORKDIR /home/$USER/run
+WORKDIR /$USER/run
 
 # switch to non-root $USER
 USER $USER
@@ -43,13 +43,13 @@ RUN pip install --no-cache-dir -r requirements.txt
 
 # copy gunicorn config file
 COPY appcontainer/gunicorn.conf.py gunicorn.conf.py
-ENV GUNICORN_CONF "/home/$USER/run/gunicorn.conf.py"
+ENV GUNICORN_CONF "/$USER/run/gunicorn.conf.py"
 
 # overwrite default nginx.conf
 COPY appcontainer/nginx.conf /etc/nginx/nginx.conf
 
 # enter app directory
-WORKDIR /home/$USER/app
+WORKDIR /$USER/app
 
 # basic bash entrypoint
 ENTRYPOINT ["/bin/bash"]

--- a/appcontainer/gunicorn.conf.py
+++ b/appcontainer/gunicorn.conf.py
@@ -6,7 +6,7 @@ More information: https://docs.gunicorn.org/en/stable/settings.html
 import multiprocessing
 
 # the unix socket defined in nginx.conf
-bind = "unix:/home/calitp/run/gunicorn.sock"
+bind = "unix:/calitp/run/gunicorn.sock"
 
 # Recommend (2 x $num_cores) + 1 as the number of workers to start off with
 workers = multiprocessing.cpu_count() * 2 + 1

--- a/appcontainer/nginx.conf
+++ b/appcontainer/nginx.conf
@@ -22,7 +22,7 @@ http {
   upstream app_server {
     # fail_timeout=0 means we always retry an upstream even if it failed
     # to return a good HTTP response
-    server unix:/home/calitp/run/gunicorn.sock fail_timeout=0;
+    server unix:/calitp/run/gunicorn.sock fail_timeout=0;
   }
 
   server {
@@ -39,7 +39,7 @@ http {
 
     # path for static files
     location /static/ {
-      alias /home/calitp/app/static/;
+      alias /calitp/app/static/;
       expires 1y;
       add_header Cache-Control public;
     }

--- a/compose.yml
+++ b/compose.yml
@@ -10,7 +10,7 @@ services:
     ports:
       - "8000"
     volumes:
-      - .:/home/calitp/app
+      - .:/calitp/app
 
   dev:
     build:
@@ -21,7 +21,7 @@ services:
     ports:
       - "8000"
     volumes:
-      - .:/home/calitp/app
+      - .:/calitp/app
 
   docs:
     image: docker-python-web:dev
@@ -30,4 +30,4 @@ services:
     ports:
       - "8001"
     volumes:
-      - .:/home/calitp/app
+      - .:/calitp/app


### PR DESCRIPTION
There are two directories with application code:

* `run/` is created by this image and contains the default `nginx` and `gunicorn` configuration
* `app/` is created by the consuming image (`benefits` or `eligibility-server`) and contains the application code

This image defines these two directories under `/home/calitp/` (the Docker `$USER`s home).

This PR moves them to the top-level `/calitp/` (again, from the Docker `$USER`).

This change is part of addressing https://github.com/cal-itp/benefits/issues/2153. When we enable the setting `WEBSITES_ENABLE_APP_SERVICE_STORAGE=true`, `/home` will be a directory managed by the Azure App Service, so we need the application code out of that directory.

## Post-merge

Merge the following PRs

* https://github.com/cal-itp/benefits/pull/2156
* https://github.com/cal-itp/eligibility-server/pull/463