### PR TITLE
Fix: change location of user pip install

### DIFF
--- a/appcontainer/Dockerfile
+++ b/appcontainer/Dockerfile
@@ -34,8 +34,12 @@ WORKDIR /$USER/run
 # switch to non-root $USER
 USER $USER
 
-# update PATH for local pip installs
-ENV PATH "$PATH:/home/$USER/.local/bin"
+# update env for local pip installs
+# see https://docs.python.org/3/using/cmdline.html#envvar-PYTHONUSERBASE
+# since all `pip install` commands are in the context of $USER
+# $PYTHONUSERBASE is the location used by default
+ENV PATH="$PATH:/$USER/.local/bin" \
+    PYTHONUSERBASE="/$USER/.local"
 
 # install python dependencies
 COPY appcontainer/requirements.txt requirements.txt


### PR DESCRIPTION
Need to move out of the `/home` directory, closes #43 

See https://docs.python.org/3/using/cmdline.html#envvar-PYTHONUSERBASE

Since all `pip install` commands are in the context of `$USER`, `$PYTHONUSERBASE` is the location used by default.

## Testing this

Build the image from this branch

```console
$ git checkout fix/pip-install-user
$ docker compose build app
```

Confirm that a container starts, and that `pip` works as expected:

```console
$ docker compose run app
calitp@de074f67aeb8:/calitp/app$ pip freeze
gunicorn==22.0.0
packaging==24.1
```

In `benefits`, update the Dockerfile to use the local image:

```diff
- FROM ghcr.io/cal-itp/docker-python-web:main
+ FROM docker-python-web:app
```

Rebuild that image:

```console
$ docker compose build client
```

Confirm that a container starts, and that `pip` works as expected:

```console
$ docker compose run --entrypoint bash client
calitp@3081438fdf32:/calitp/app$ pip freeze
asgiref==3.8.1
Authlib==1.3.1
azure-core==1.30.2
azure-identity==1.16.0
azure-keyvault-secrets==4.8.0
# Editable install with no version control (benefits==2024.6.1)
-e /calitp/app
cachetools==5.3.3
calitp-littlepay==2024.6.1
...
```

Confirm that the app runs (will reset/reload the DB according to your `.env`):

```console
$ docker compose run -P client bin/test_start.sh
```

_`-P` is needed for `run` to ensure the port is bound_

Go to `http://localhost:<port>` and confirm the app is running as expected.