### PR TITLE
feat: publish to ghcr on tag push

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -4,8 +4,8 @@ on:
   workflow_dispatch:
   push:
     tags:
-      - "[0-9]+.[0-9]+.[0-9]+"
-      - "[0-9]+.[0-9]+.[0-9]+-rc.?[0-9]+"
+      - "[0-9]+.[0-9]+.[0-9]+" # SemVer release
+      - "[0-9]+.[0-9]+.[0-9]+-**" # SemVer pre-release
 
 defaults:
   run:
@@ -58,7 +58,8 @@ jobs:
 
   release:
     needs: publish
-    if: ${{ !contains(github.ref_name, '-rc') }}
+    # signifies a SemVer pre-release https://semver.org/#spec-item-9
+    if: ${{ !contains(github.ref_name, '-') }}
     runs-on: ubuntu-latest
     permissions:
       # https://github.com/softprops/action-gh-release#permissions

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -3,8 +3,9 @@ name: Publish image to GHCR
 on:
   workflow_dispatch:
   push:
-    branches:
-      - main
+    tags:
+      - "[0-9]+.[0-9]+.[0-9]+"
+      - "[0-9]+.[0-9]+.[0-9]+-rc.?[0-9]+"
 
 defaults:
   run:
@@ -19,30 +20,29 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Docker Login to GitHub Container Registry
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
+        uses: docker/setup-qemu-action@v4
 
       - name: Set up Docker Buildx
         id: buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       - name: Cache Parameters
         id: cache_params
         run: |
           CACHE_SCOPE="cal-itp"
-          MAIN_BRANCH_REF="refs/heads/main"
 
-          echo "cache_from_args=type=gha,scope=${CACHE_SCOPE},ref=${MAIN_BRANCH_REF}" >> $GITHUB_OUTPUT
-          echo "cache_to_args=type=gha,scope=${CACHE_SCOPE},mode=max,ref=${MAIN_BRANCH_REF}" >> $GITHUB_OUTPUT
+          echo "cache_from_args=type=gha,scope=${CACHE_SCOPE},ref=${{ github.ref }}" >> $GITHUB_OUTPUT
+          echo "cache_to_args=type=gha,scope=${CACHE_SCOPE},mode=max,ref=${{ github.ref }}" >> $GITHUB_OUTPUT
 
       - name: Build, tag, and push image to GitHub Container Registry
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           builder: ${{ steps.buildx.outputs.name }}
           build-args: GIT-SHA=${{ github.sha }}
@@ -55,3 +55,23 @@ jobs:
           tags: |
             ghcr.io/${{ github.repository }}:${{ github.ref_name }}
             ghcr.io/${{ github.repository }}:${{ github.sha }}
+
+  release:
+    needs: publish
+    if: ${{ !contains(github.ref_name, '-rc') }}
+    runs-on: ubuntu-latest
+    permissions:
+      # https://github.com/softprops/action-gh-release#permissions
+      contents: write
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Release
+        uses: softprops/action-gh-release@v2
+        with:
+          prerelease: false
+          generate_release_notes: true

--- a/README.md
+++ b/README.md
@@ -21,10 +21,10 @@ A base [Docker image](https://www.docker.com/) for Cal-ITP Python web applicatio
 
 ## Usage
 
-Reference one of the `image:tag` from GitHub Container Registry in a `Dockerfile`. E.g. for the `main` branch:
+Reference an `image:tag` from GitHub Container Registry in a `Dockerfile`. E.g. for the `1.0.0` release:
 
 ```dockerfile
-FROM ghcr.io/cal-itp/docker-python-web:main
+FROM ghcr.io/cal-itp/docker-python-web:1.0.0
 
 COPY my_app my_app
 
@@ -34,7 +34,7 @@ CMD "nginx && python -m gunicorn -c $GUNICORN_CONF my_app.wsgi"
 Or from the command line:
 
 ```shell
-docker pull ghcr.io/cal-itp/docker-python-web:main
+docker pull ghcr.io/cal-itp/docker-python-web:1.0.0
 ```
 
 ## Development

--- a/appcontainer/Dockerfile
+++ b/appcontainer/Dockerfile
@@ -20,6 +20,11 @@ ARG PYTHON_VERSION \
     USER_UID \
     USER_GID
 
+# https://docs.github.com/en/packages/working-with-a-github-packages-registry/working-with-the-container-registry#labelling-container-images
+LABEL org.opencontainers.image.source=https://github.com/cal-itp/docker-python-web
+LABEL org.opencontainers.image.description="A base Docker image for Cal-ITP Python web applications"
+LABEL org.opencontainers.image.licenses="Apache-2.0"
+
 # set env vars for the user, including HOME
 ENV PYTHONUNBUFFERED=${PYTHONUNBUFFERED} \
     PYTHONDONTWRITEBYTECODE=${PYTHONDONTWRITEBYTECODE} \

--- a/docs/guides/publish-an-image.md
+++ b/docs/guides/publish-an-image.md
@@ -2,9 +2,9 @@
 
 Historically, a new image was published each time a commit was pushed to `main`. Now we use [tag-based deployment](https://github.com/cal-itp/docker-python-web/issues/73).
 
-The steps to release are nearly identical to [benefits](https://docs.calitp.org/benefits/guides/release/), with the exception that we use a [SemVer](https://semver.org/) numbering scheme.
+The steps to release are nearly identical to [Benefits](https://docs.calitp.org/benefits/guides/release/), with the exception that we use a [SemVer](https://semver.org/) numbering scheme.
 
-## 0. Decide on the new version number
+## Decide on the new version number
 
 Given a version number `MAJOR.MINOR.PATCH`, increment the:
 

--- a/docs/guides/publish-an-image.md
+++ b/docs/guides/publish-an-image.md
@@ -1,0 +1,22 @@
+# Publish an image
+
+Historically, a new image was published each time a commit was pushed to `main`. Now we use [tag-based deployment](https://github.com/cal-itp/docker-python-web/issues/73).
+
+The steps to release are nearly identical to [benefits](https://docs.calitp.org/benefits/guides/release/), with the exception that we use a [SemVer](https://semver.org/) numbering scheme.
+
+## 0. Decide on the new version number
+
+Given a version number `MAJOR.MINOR.PATCH`, increment the:
+
+- MAJOR version when you make incompatible API changes
+- MINOR version when you add functionality in a backward compatible manner
+- PATCH version when you make backward compatible bug fixes
+
+Images are published to the GitHub Container Registry when a tag is pushed with a version number similar to either of the following:
+
+```bash
+# genuine release
+1.2.3
+# release candidate
+2.3.4-rc.1
+```

--- a/docs/guides/publish-an-image.md
+++ b/docs/guides/publish-an-image.md
@@ -12,7 +12,7 @@ Given a version number `MAJOR.MINOR.PATCH`, increment the:
 - MINOR version when you add functionality in a backward compatible manner
 - PATCH version when you make backward compatible bug fixes
 
-Images are published to the GitHub Container Registry when a tag is pushed with a version number similar to either of the following:
+Images are published to the GitHub Container Registry [when a tag is pushed](https://docs.calitp.org/benefits/guides/release/#2-create-a-release-tag-on-main-and-push-it) with a version number similar to either of the following:
 
 ```bash
 # genuine release


### PR DESCRIPTION
resolves #73 and supercedes #67, #68, #69, #70

* stops tagging on push to `main`
* publishes a new docker image when a SemVer compliant tag is pushed
* publishes a github release when a non-RC SemVer release is detected

i created a test release from [1.0.0-rc.0](https://github.com/cal-itp/docker-python-web/releases/tag/1.0.0-rc.0) to see what 1.0.0 will look like. i will delete it before this PR is merged.

based on what i'm seeing in https://github.com/dependabot/dependabot-core/issues/13383 we may have to do a bit more to configure 'manifests' for this image in order to get Dependabot wired up correctly or it may be that we'll encounter the same bug regardless.

my proposal is to tag what we already have as 1.0.0 and refine if necessary after we land https://github.com/cal-itp/benefits/pull/3667.

## Labeling notes
when i saw that the `org.opencontainers.image.description` label was omitted from the ghcr landing page for [1.0.0-rc.0](https://github.com/cal-itp/docker-python-web/pkgs/container/docker-python-web/802762132?tag=1.0.0-rc.0) i went down a bit of a rabbithole trying different techniques that are supposed to work for multi-arch images without much success. ~for now you can see some intermediate commits in this branch associated with that effort.~

given 👇 i decided not to sink any more time into it unless someone else feels its a genuine value-add.

```bash
$ docker pull ghcr.io/cal-itp/docker-python-web:1.0.0-rc.0
$ docker inspect --format='{{json .Config.Labels}}' ghcr.io/cal-itp/docker-python-web:1.0.0-rc.0 | jq

{
  "org.opencontainers.image.description": "A base Docker image for Cal-ITP Python web applications",
  "org.opencontainers.image.licenses": "Apache-2.0",
  "org.opencontainers.image.source": "https://github.com/calitp/docker-python-web"
}
```
ref: https://github.com/orgs/community/discussions/45969#discussioncomment-13566833